### PR TITLE
Suggestion

### DIFF
--- a/inc/plugins/statusfeed.php
+++ b/inc/plugins/statusfeed.php
@@ -380,7 +380,11 @@ function statusfeed_info() {
 
 		}
 		$status_updates = $feed;
-			
+		
+		if ($mybb->user['uid'] > 0) {
+			eval("\$statusfeed_form = \"".$templates->get("statusfeed_form")."\";");
+		}
+		
 		// $pagination = multipage($numrows, $rowsperpage, $currentpage, "member.php?action=profile&uid=$profile_UID");
 		$statusfeed_viewall = '<center><a href="statusfeed.php">'.$lang->statusfeed_view_all_updates.'</a></center>';
 		eval("\$statusfeed = \"".$templates->get("statusfeed_portal")."\";");

--- a/inc/plugins/statusfeed.php
+++ b/inc/plugins/statusfeed.php
@@ -267,6 +267,10 @@ function statusfeed_info() {
 			$pagination = multipage_ajax($numrows, $rowsperpage, $currentpage, "member.php?action=profile&uid=$profile_UID", $profile_UID);
 		}		
 		
+		if ($mybb->user['uid'] > 0) {
+			eval("\$statusfeed_form = \"".$templates->get("statusfeed_form")."\";");
+		}
+		
 		$status_updates = $feed;
 		eval("\$statusfeed_profile = \"".$templates->get($altTemplate)."\";");
 

--- a/inc/plugins/statusfeed/install_functions.php
+++ b/inc/plugins/statusfeed/install_functions.php
@@ -371,12 +371,7 @@ $(\'.sf_comment_form_{$parent}\').on(\'submit\', function (e) {
         <td class="trow2" colspan="2">
         {$pagination}
             <form id="sf_form_profile">
-                <div style="statusfeed_portal_formcontainer">
-<textarea name="status" rows="2" class="statusfeed_all_textarea" onfocus="if(this.value == \'{$lang->statusfeed_update_status_textbox}\') {this.value=\'\';}" onblur="if(this.value==\'\') {this.value=\'{$lang->statusfeed_update_status_textbox}\';}">{$lang->statusfeed_update_status_textbox}</textarea>
-                    <input type="hidden" name="wall_id" value="{$profile_UID}">
-                    <input type="hidden" name="post_key" value="{$mybb->post_code}">
-<input type="submit" value="{$lang->statusfeed_update_status}" class="statusfeed_block_submit button">
-                </div>
+                {$statusfeed_form}
             </form>
         </td>
     </tr>
@@ -411,13 +406,7 @@ $(\'.sf_comment_form_{$parent}\').on(\'submit\', function (e) {
                     {$pagination}
                     <br />
                     <form id="sf_form_all">
-                        <div class="statusfeed_portal_formcontainer">
-                            <textarea name="status" rows="2" class="statusfeed_all_textarea" onfocus="if(this.value == \'{$lang->statusfeed_update_status_textbox}\') {this.value=\'\';}" onblur="if(this.value==\'\') {this.value=\'{$lang->statusfeed_update_status_textbox}\';}">{$lang->statusfeed_update_status_textbox}</textarea>
-                            <input type="hidden" name="wall_id" value="{$profile_UID}">
-                            <input type="hidden" name="reply_id" value="-1">
-                            <input type="hidden" name="post_key" value="{$mybb->post_code}">
-                            <input type="submit" value="{$lang->statusfeed_update_status}" class="button statusfeed_all_submitbutton">
-                        </div>
+                        {$statusfeed_form}
                     </form>
                 </td>
             </tr>
@@ -444,12 +433,7 @@ $(\'.sf_comment_form_{$parent}\').on(\'submit\', function (e) {
     <tr>
         <td class="trow1" colspan="2">
         <form id="sf_form_{$statusStyle}">
-                <div class="statusfeed_portal_formcontainer">
-                    <textarea name="status" rows="2" class="statusfeed_portal_textarea" onfocus="if(this.value == \'{$lang->statusfeed_update_status_textbox}\') {this.value=\'\';}" onblur="if(this.value==\'\') {this.value=\'{$lang->statusfeed_update_status_textbox}\';}">{$lang->statusfeed_update_status_textbox}</textarea>
-                    <input type="hidden" name="reply_id" value="-1">
-                    <input type="hidden" name="post_key" value="{$mybb->post_code}">
-<input type="submit" value="{$lang->statusfeed_update_status}" class="button statusfeed_portal_submit">
-                </div>
+                {$statusfeed_form}
             </form>
         {$statusfeed_viewall}
         </td>
@@ -458,6 +442,14 @@ $(\'.sf_comment_form_{$parent}\').on(\'submit\', function (e) {
 <br />
 ';
 
+    $template['statusfeed_form'] = '<div class="statusfeed_portal_formcontainer">
+    <textarea name="status" rows="2" class="statusfeed_all_textarea" onfocus="if(this.value == \'{$lang->statusfeed_update_status_textbox}\') {this.value=\'\';}" onblur="if(this.value==\'\') {this.value=\'{$lang->statusfeed_update_status_textbox}\';}">{$lang->statusfeed_update_status_textbox}</textarea>
+    <input type="hidden" name="reply_id" value="-1">
+    <input type="hidden" name="post_key" value="{$mybb->post_code}">
+    <input type="submit" value="{$lang->statusfeed_update_status}" class="button statusfeed_portal_submit">
+</div>
+';
+	
 // Old: Remove the _{$StatusStyle} from the form IDs and uncomment the script. 
 
     $template['statusfeed_popup'] = '
@@ -497,12 +489,7 @@ $(\'.sf_comment_form_{$parent}\').on(\'submit\', function (e) {
 					<td class="trow2" colspan="2">
 					{$pagination}
 						<form id = "sf_form">
-							<div class="statusfeed_portal_formcontainer">
-		<textarea name="status" rows="2" class="statusfeed_portal_textarea" placeholder = "{$lang->statusfeed_write_status_popup}">{$lang->statusfeed_write_status_popup}</textarea>
-								<input type="hidden" name="wall_id" value="{$profile_UID}">
-								<input type="hidden" name="post_key" value="{$mybb->post_code}">
-		<input type="submit" value="{$lang->statusfeed_update_status}" style="width: 100%; " class="button statusfeed_portal_submit">
-							</div>
+							{$statusfeed_form}
 						</form>
 					</td>
 				</tr>

--- a/inc/plugins/statusfeed/install_functions.php
+++ b/inc/plugins/statusfeed/install_functions.php
@@ -805,7 +805,7 @@ function statusfeed_uninstall () {
     $db->write_query("ALTER TABLE `".TABLE_PREFIX."users` DROP `sf_unreadcomments`;");
     $db->write_query("ALTER TABLE `".TABLE_PREFIX."users` DROP `sf_currentstatus`;");
     
-    $templates_to_remove = array('statusfeed_portal', 'statusfeed_popup', 'statusfeed_profile', 'statusfeed_comment_mini', 'statusfeed_comment_full', 'statusfeed_likeButton', 'statusfeed_reportButton', 'statusfeed_postbit', 'statusfeed_notifications_container', 'statusfeed_notification', 'statusfeed_postbit', 'statusfeed_edit', 'statusfeed_all', 'statusfeed_post_full', 'statusfeed_post_mini', 'statusfeed_comments_container');
+    $templates_to_remove = array('statusfeed_portal', 'statusfeed_popup', 'statusfeed_profile', 'statusfeed_comment_mini', 'statusfeed_comment_full', 'statusfeed_likeButton', 'statusfeed_reportButton', 'statusfeed_postbit', 'statusfeed_notifications_container', 'statusfeed_notification', 'statusfeed_postbit', 'statusfeed_edit', 'statusfeed_all', 'statusfeed_post_full', 'statusfeed_post_mini', 'statusfeed_comments_container', 'statusfeed_form');
     foreach($templates_to_remove as $data) {
         $db->delete_query('templates', "title = '{$data}'");
     }


### PR DESCRIPTION
This suggestion is based on redundancy first and foremost. In multiple templates, there is very similar code, that although have differences, still don't enable the plugin functionality wise.

These changes are merely suggestions, what is done is:

- statusfeed_form template is added in install functions
- statusfeed_portal, statusfeed_popup, statusfeed_profile, statusfeed_all have been changed to include $statusfeed_form variable
- statusfeed_form is now only eval'd if a user is logged in (thus hiding the reply option for guests)